### PR TITLE
First implementation of custom field processor

### DIFF
--- a/api/src/main/java/io/neba/api/resourcemodels/fieldprocessor/CustomFieldProcessor.java
+++ b/api/src/main/java/io/neba/api/resourcemodels/fieldprocessor/CustomFieldProcessor.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2013 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+package io.neba.api.resourcemodels.fieldprocessor;
+
+import org.apache.sling.api.resource.Resource;
+import org.springframework.beans.factory.BeanFactory;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+
+/**
+ * A custom field processor is a service that is registered by NEBA.
+ * When NEBA maps a resource to a model, all fields that are
+ * {@link #accept(Field, Object)}  accepted} by a processor, are processed by this
+ * processor instead of standard NEBA handling.
+ * The assignment of fields to their processors are cached.
+ * It is not allowed that more than one processor accepts a field.
+ * 
+ * @author christoph.huber
+ */
+public interface CustomFieldProcessor {
+
+    /**
+     * Callback function that processes a non-collection field.
+     *
+     * @param field The field to be mapped. Use this read-only, the returned value is injected by NEBA.
+     * @param typeParameter If the field type has parameters, the parameter is returned.
+     *                      Example: <code>String</code> for type <code>Optional&lt;String&gt;</code>
+     * @param resourceModel The resource model to be mapped. <code>field</code> is part of this model.
+     * @param resource The resource to be mapped onto the model.
+     * @param factory The Sprint bean factory.
+     * @param <T> The field's type to be returned.
+     * @param <P> The type parameter's type.
+     * @param <M> The resource model type.
+     * @return <code>null</code> if field cannot be mapped. The mapped value that is injected into the field.
+     */
+    <T, P, M> T processField(Field field, Class<P> typeParameter, M resourceModel,
+                      Resource resource, BeanFactory factory);
+
+    /**
+     * Callback function that processes a collection field.
+     *
+     * @param field The field to be mapped. Use this read-only, the returned value is injected by NEBA.
+     * @param initialCollection An empty collection of <code>field</code>'s type. Add the mapped properties
+     *                          to this collection.
+     * @param typeParameter The collection's type parameter.
+     *                      Example: <code>String</code> for type <code>List&lt;String&gt;</code>
+     * @param resourceModel The resource model to be mapped. <code>field</code> is part of this model.
+     * @param resource The resource to be mapped onto the model.
+     * @param factory The Sprint bean factory.
+     * @param <P> The type parameter's type.
+     * @param <M> The resource model type.
+     */
+    <P, M> void processCollection(Field field, Collection initialCollection, Class<P> typeParameter,
+                            M resourceModel, Resource resource, BeanFactory factory);
+
+    /**
+     * If a field is accepted, NEBA will no more handle this! No matter whether there are
+     * NEBA annotations defined for this field.
+     * A common use case is to implemented accept() by checking the field for a custom annotation like
+     * <code>return field.isAnnotationPresent(MyAnnotation.class)</code>
+     * @return
+     */
+    <M> boolean accept(Field field, M resourceModel);
+}

--- a/core/src/main/java/io/neba/core/resourcemodels/fieldprocessor/FieldProcessorRegistrar.java
+++ b/core/src/main/java/io/neba/core/resourcemodels/fieldprocessor/FieldProcessorRegistrar.java
@@ -1,0 +1,113 @@
+package io.neba.core.resourcemodels.fieldprocessor;
+
+import io.neba.api.resourcemodels.fieldprocessor.CustomFieldProcessor;
+import io.neba.core.resourcemodels.metadata.ResourceModelMetaDataRegistrar;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Registers {@link CustomFieldProcessor} per resource model.
+ * When a processor is added or removed, the affected resource model metadata has to be
+ * {@link ResourceModelMetaDataRegistrar#invalidate(List) invalidated}.
+ *
+ * @author christoph.huber
+ * @since 05.12.2014
+ */
+@Service
+public class FieldProcessorRegistrar {
+    @Inject
+    private ResourceModelMetaDataRegistrar metaDataRegistrar;
+
+    private Map<Class<?>, List<CustomFieldProcessor>> resourceModelProcessors =
+            Collections.synchronizedMap(new HashMap<Class<?>, List<CustomFieldProcessor>>());
+    private List<CustomFieldProcessor> fieldProcessors =
+            Collections.synchronizedList(new LinkedList<CustomFieldProcessor>());
+
+    public void add(CustomFieldProcessor customFieldProcessor) {
+        fieldProcessors.add(customFieldProcessor);
+        metaDataRegistrar.invalidate(addProcessorToResourceModels(customFieldProcessor));
+    }
+    public void remove(CustomFieldProcessor customFieldProcessor) {
+        fieldProcessors.remove(customFieldProcessor);
+        metaDataRegistrar.invalidate(removeProcessorFromResourceModels(customFieldProcessor));
+    }
+
+    private List<Class<?>> addProcessorToResourceModels(CustomFieldProcessor processor) {
+        List<Class<?>> changedModels = new LinkedList<Class<?>>();
+        for (Map.Entry<Class<?>, List<CustomFieldProcessor>> entry : resourceModelProcessors.entrySet()) {
+            for (Field field : entry.getKey().getDeclaredFields()) {
+                if (processor.accept(field, entry.getKey())) {
+                    entry.getValue().add(processor);
+                    changedModels.add(entry.getKey());
+                    break;
+                }
+            }
+        }
+        return changedModels;
+    }
+    private List<Class<?>> removeProcessorFromResourceModels(CustomFieldProcessor processor) {
+        List<Class<?>> changedModels = new LinkedList<Class<?>>();
+        for (Map.Entry<Class<?>, List<CustomFieldProcessor>> entry : resourceModelProcessors.entrySet()) {
+            if (entry.getValue().contains(processor)) {
+                entry.getValue().remove(processor);
+                changedModels.add(entry.getKey());
+            }
+        }
+        return changedModels;
+    }
+
+    /**
+     * This would actually require a complete invalidation of the cached resource model metadata.
+     * But since both registrars are in the same bundle, both caches should be cleared anyway.
+     */
+    @PreDestroy
+    public void cleanUp() {
+        fieldProcessors.clear();
+        resourceModelProcessors.clear();
+    }
+
+    /**
+     * Is called when a new resource model is registered.
+     * @return All processors that affect the provided model.
+     */
+    public List<CustomFieldProcessor> addModel(Class<?> modelType) {
+        List<CustomFieldProcessor> modelProcessors = new LinkedList<CustomFieldProcessor>();
+        for (CustomFieldProcessor processor : fieldProcessors) {
+            for (Field field : modelType.getDeclaredFields()) {
+                if (processor.accept(field, modelType)) {
+                    modelProcessors.add(processor);
+                    break;
+                }
+            }
+        }
+        resourceModelProcessors.put(modelType, modelProcessors);
+        return modelProcessors;
+    }
+
+    /**
+     * Is called when a registered resource model is deactivated.
+     */
+    public void removeModel(Class<?> modelType) {
+        resourceModelProcessors.remove(modelType);
+    }
+
+    /**
+     * Returns all processors appliable to at least one field of <code>modelType</code>.
+     * @return Never <code>null</code>.
+     */
+    public List<CustomFieldProcessor> getProcessors(Class<?> modelType) {
+        List<CustomFieldProcessor> processors = resourceModelProcessors.get(modelType);
+        if (processors == null) {
+            return Collections.emptyList();
+        }
+        return processors;
+    }
+}

--- a/core/src/main/resources/META-INF/spring/extender/context.xml
+++ b/core/src/main/resources/META-INF/spring/extender/context.xml
@@ -52,6 +52,10 @@
 		<bp:reference-list interface="io.neba.api.resourcemodels.ResourceModelPostProcessor" availability="optional">
 			<bp:reference-listener ref="resourceToModelMapper" bind-method="add" unbind-method="remove" />
 		</bp:reference-list>
+		<!-- All custom field processors are used by the field processor registrar -->
+		<bp:reference-list interface="io.neba.api.resourcemodels.fieldprocessor.CustomFieldProcessor" availability="optional">
+			<bp:reference-listener ref="fieldProcessorRegistrar" bind-method="add" unbind-method="remove" />
+		</bp:reference-list>
 		<!-- All caches are used by the adapter factory -->
 		<bp:reference-list interface="io.neba.api.resourcemodels.ResourceModelCache" availability="optional">
 			<bp:reference-listener ref="resourceModelCaches" bind-method="add" unbind-method="remove" />

--- a/core/src/test/java/io/neba/core/resourcemodels/fieldprocessor/FieldProcessorRegistrarTest.java
+++ b/core/src/test/java/io/neba/core/resourcemodels/fieldprocessor/FieldProcessorRegistrarTest.java
@@ -1,0 +1,115 @@
+package io.neba.core.resourcemodels.fieldprocessor;
+
+import io.neba.api.resourcemodels.fieldprocessor.CustomFieldProcessor;
+import io.neba.core.resourcemodels.mapping.testmodels.TestResourceModel;
+import io.neba.core.resourcemodels.metadata.ResourceModelMetaDataRegistrar;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.verification.VerificationMode;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FieldProcessorRegistrarTest {
+
+    @Mock
+    private ResourceModelMetaDataRegistrar resourceModelMetaDataRegistrar;
+
+    @Mock
+    private CustomFieldProcessor testFieldProcessor;
+
+    @InjectMocks
+    private FieldProcessorRegistrar testee;
+
+    @Test
+    public void testProcessorIsAddedWithoutModels() {
+        withProcessorsAcceptingAnyField(testFieldProcessor);
+        addProcessor(testFieldProcessor);
+        assertEmptyCacheEntry(TestResourceModel.class);
+    }
+
+    @Test
+    public void testProcessorIsAddedWithExistingModels() {
+        withProcessorsAcceptingAnyField(testFieldProcessor);
+        addModel(TestResourceModel.class);
+        addProcessor(testFieldProcessor);
+        assertCacheEntry(TestResourceModel.class, testFieldProcessor);
+        assertMetaDataInvalidated(TestResourceModel.class, times(1));
+    }
+
+    @Test
+    public void testModelIsAdded() {
+        withProcessorsAcceptingAnyField(testFieldProcessor);
+        addProcessor(testFieldProcessor);
+        addModel(TestResourceModel.class, testFieldProcessor);
+        assertCacheEntry(TestResourceModel.class, testFieldProcessor);
+    }
+
+    @Test
+    public void testProcessorIsRemoved() {
+        withProcessorsAcceptingAnyField(testFieldProcessor);
+        addModel(TestResourceModel.class);
+        addProcessor(testFieldProcessor);
+        removeProcessor(testFieldProcessor);
+        assertEmptyCacheEntry(TestResourceModel.class);
+        assertMetaDataInvalidated(TestResourceModel.class, times(2));
+    }
+
+    @Test
+    public void testModelIsRemoved() {
+        withProcessorsAcceptingAnyField(testFieldProcessor);
+        addModel(TestResourceModel.class);
+        addProcessor(testFieldProcessor);
+        removeModel(TestResourceModel.class);
+        assertEmptyCacheEntry(TestResourceModel.class);
+        assertMetaDataInvalidated(TestResourceModel.class, times(1));
+    }
+
+    @Test
+    public void testProcessorThatNotAcceptsAnyField() {
+        addProcessor(testFieldProcessor);
+        addModel(TestResourceModel.class);
+        assertEmptyCacheEntry(TestResourceModel.class);
+    }
+
+    private void withProcessorsAcceptingAnyField(CustomFieldProcessor processor) {
+        when(processor.accept(any(Field.class), any())).thenReturn(true);
+    }
+
+    private void addModel(Class<?> modelType, CustomFieldProcessor... expectedProcessors) {
+        assertThat(testee.addModel(modelType)).isEqualTo(Arrays.asList(expectedProcessors));
+    }
+    private void removeModel(Class<?> modelType) {
+        testee.removeModel(modelType);
+    }
+    private void addProcessor(CustomFieldProcessor processor) {
+        testee.add(processor);
+    }
+    private void removeProcessor(CustomFieldProcessor processor) {
+        testee.remove(processor);
+    }
+
+    private void assertEmptyCacheEntry(Class<?> modelType) {
+        assertThat(testee.getProcessors(modelType)).isEmpty();
+    }
+    private void assertCacheEntry(Class<?> modelType, CustomFieldProcessor processor) {
+        assertThat(testee.getProcessors(modelType)).contains(processor);
+    }
+    private void assertMetaDataInvalidated(Class<?> modelType, VerificationMode times) {
+        List<Class<?>> modelTypes = new ArrayList<Class<?>>();
+        modelTypes.add(modelType);
+        verify(resourceModelMetaDataRegistrar, times).invalidate(modelTypes);
+    }
+}

--- a/core/src/test/java/io/neba/core/resourcemodels/mapping/ModelProcessorTest.java
+++ b/core/src/test/java/io/neba/core/resourcemodels/mapping/ModelProcessorTest.java
@@ -18,6 +18,7 @@ package io.neba.core.resourcemodels.mapping;
 
 import io.neba.api.annotations.PostMapping;
 import io.neba.api.annotations.PreMapping;
+import io.neba.api.resourcemodels.fieldprocessor.CustomFieldProcessor;
 import io.neba.core.resourcemodels.metadata.ResourceModelMetaData;
 import org.apache.sling.api.resource.Resource;
 import org.junit.Before;
@@ -28,6 +29,9 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.beans.factory.BeanFactory;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import static org.fest.assertions.Assertions.assertThat;
 
 /**
@@ -37,6 +41,7 @@ import static org.fest.assertions.Assertions.assertThat;
 public class ModelProcessorTest {
     private boolean throwExceptionDuringPreMapping;
     private boolean throwExceptionDuringPostMapping;
+    private List<CustomFieldProcessor> customFieldProcessors = new LinkedList<CustomFieldProcessor>();
 
     /**
      * @author Olaf Otto
@@ -150,7 +155,7 @@ public class ModelProcessorTest {
 
     private void withModel(final TestModel testModel) {
         this.model = testModel;
-        this.metadata = new ResourceModelMetaData(this.model.getClass());
+        this.metadata = new ResourceModelMetaData(this.model.getClass(), customFieldProcessors);
     }
 
     private void processBeforeMapping() {

--- a/core/src/test/java/io/neba/core/resourcemodels/metadata/ResourceModelMetaDataTest.java
+++ b/core/src/test/java/io/neba/core/resourcemodels/metadata/ResourceModelMetaDataTest.java
@@ -16,6 +16,7 @@
 
 package io.neba.core.resourcemodels.metadata;
 
+import io.neba.api.resourcemodels.fieldprocessor.CustomFieldProcessor;
 import io.neba.core.resourcemodels.mapping.testmodels.ExtendedTestResourceModel;
 import io.neba.core.resourcemodels.mapping.testmodels.TestResourceModel;
 import org.fest.assertions.Assertions;
@@ -25,6 +26,8 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.lang.reflect.Field;
+import java.util.LinkedList;
+import java.util.List;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.springframework.util.ReflectionUtils.findField;
@@ -39,6 +42,8 @@ public class ResourceModelMetaDataTest {
 	private Class<?> modelType;
 	
 	private ResourceModelMetaData testee;
+
+	private List<CustomFieldProcessor> customFieldProcessors = new LinkedList<CustomFieldProcessor>();
 
 	@Before
 	public void prepare() {
@@ -76,7 +81,7 @@ public class ResourceModelMetaDataTest {
         MethodMetaData[] preMappingMethods = this.testee.getPreMappingMethods();
 		MethodMetaData[] postMappingMethods = this.testee.getPostMappingMethods();
 		
-		ResourceModelMetaData other = new ResourceModelMetaData(otherModel);
+		ResourceModelMetaData other = new ResourceModelMetaData(otherModel, customFieldProcessors);
 		
 		Assertions.assertThat(mappableFields).isEqualTo(other.getMappableFields());
 		Assertions.assertThat(postMappingMethods).isEqualTo(other.getPostMappingMethods());
@@ -85,7 +90,7 @@ public class ResourceModelMetaDataTest {
 
 	private void createMetadataFor(Class<?> modelType) {
 		this.modelType = modelType;
-		this.testee = new ResourceModelMetaData(modelType);
+		this.testee = new ResourceModelMetaData(modelType, customFieldProcessors);
 	}
 
 	private void assertMappableFieldsDoesNotContain(String name) {


### PR DESCRIPTION
This is my suggestion for https://github.com/unic/neba/issues/16. It seems to work well. But I'm not very happy about the importance the CustomFieldProcessor has now. It influences the ResourceModelMetaDataRegistrar until the creation of the meta data. Maybe a more elegant solution, where the basic neba components have less touchpoints to the extension can be found. But at least, this is what I expect. With this change, I could simplify a PostProcessor from 250 to 110 LoC. It only contains now the computation of the field value to inject and does not do anything related to reflection or field injection.