### PR TITLE
 neba.io: Hide Claim on Mobile Devices - Issue #41

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3506,6 +3506,10 @@ html[xmlns] .slides {
         width: 714px;
         height: auto;
     }
+
+    #claim {
+        display: none;
+    }
 }
 
 /*---------------iPhone landscape---------------*/
@@ -3525,6 +3529,10 @@ html[xmlns] .slides {
     }
 
     .flex-caption, .pagination {
+        display: none;
+    }
+
+    #claim {
         display: none;
     }
 }
@@ -3552,6 +3560,10 @@ html[xmlns] .slides {
     #index-slider .slider-claim {
         font-size: inherit;
         line-height: inherit;
+    }
+
+    #claim {
+        display: none;
     }
 }
 


### PR DESCRIPTION
- When the site is viewed on mobile devices, the claim next to the logo disappears now.

- Also, that one weird resolution is now fixed. Used to look like:

![2015-03-05 14-30-15_neba - the best of sling powered by spring](https://cloud.githubusercontent.com/assets/10851587/6596888/bcc116ec-c7f8-11e4-8c5a-cda0d64fb579.png)
