### PR TITLE
Review: Improved FieldValueMappingCallback + Optional / default value testing and documentation

### DIFF
--- a/core/src/main/java/io/neba/core/resourcemodels/mapping/FieldValueMappingCallback.java
+++ b/core/src/main/java/io/neba/core/resourcemodels/mapping/FieldValueMappingCallback.java
@@ -140,9 +140,10 @@ public class FieldValueMappingCallback {
      */
     private Object postProcessResolvedValue(FieldData fieldData, Object value) {
         // For convenience, NEBA guarantees that any mappable collection-typed field is never <code>null</code> but rather
-        // an empty collection, in case no non-<code>null</code> default value was provided.
+        // an empty collection, in case no non-<code>null</code> default value was provided and field is not Optional.
         boolean preventNullCollection =
                 value == null &&
+                !fieldData.metaData.isOptional() &&
                 fieldData.metaData.isInstantiableCollectionType() &&
                 getField(fieldData.metaData.getField(), this.model) == null;
 

--- a/core/src/main/java/io/neba/core/resourcemodels/metadata/MappedFieldMetaData.java
+++ b/core/src/main/java/io/neba/core/resourcemodels/metadata/MappedFieldMetaData.java
@@ -318,7 +318,8 @@ public class MappedFieldMetaData {
     }
 
     /**
-     * @return the {@link java.lang.reflect.Field#getType() field type}.
+     * @return the type the resolved value for the field shall have, which is either the {@link java.lang.reflect.Field#getType() field type},
+     * or the generic parameter type in case of {@link #isOptional() optional} fields.
      */
     public Class<?> getType() {
         return this.fieldType;


### PR DESCRIPTION
 - Made the fact that non-null collection values are not prevented in Optional fields explicit
 - Improved test formatting and parameter / method naming
 - Improved description of semantics in MappedFieldMetaData#getType