### PR TITLE
Provide AspectJ bundle to resolve dependency problems with spring-aop

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -78,6 +78,10 @@
             <artifactId>org.apache.servicemix.bundles.aopalliance</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.aspectj</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/delivery-aem/pom.xml
+++ b/delivery-aem/pom.xml
@@ -62,6 +62,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.aspectj</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.spring-expression</artifactId>
         </dependency>
         <dependency>
@@ -139,7 +143,7 @@
                         </goals>
                         <configuration>
                             <includeGroupIds>org.apache.servicemix.bundles</includeGroupIds>
-                            <excludeArtifactIds>org.apache.servicemix.bundles.aopalliance</excludeArtifactIds>
+                            <excludeArtifactIds>org.apache.servicemix.bundles.aopalliance,org.apache.servicemix.bundles.aspectj</excludeArtifactIds>
                             <useSubDirectoryPerArtifact>true</useSubDirectoryPerArtifact>
                             <outputDirectory>${spring.artifacts.workdir}</outputDirectory>
                         </configuration>
@@ -185,6 +189,11 @@
                         <embedded>
                             <groupId>org.apache.servicemix.bundles</groupId>
                             <artifactId>org.apache.servicemix.bundles.aopalliance</artifactId>
+                            <target>${neba.installation.path}</target>
+                        </embedded>
+                        <embedded>
+                            <groupId>org.apache.servicemix.bundles</groupId>
+                            <artifactId>org.apache.servicemix.bundles.aspectj</artifactId>
                             <target>${neba.installation.path}</target>
                         </embedded>
                         <embedded>

--- a/delivery-aem/src/main/resources/vault-work/jcr_root/apps/neba/install/.content.xml
+++ b/delivery-aem/src/main/resources/vault-work/jcr_root/apps/neba/install/.content.xml
@@ -7,6 +7,7 @@
     bundles are started before the spring bundles are installed.
      -->
     <org.apache.servicemix.bundles.aopalliance-1.0_6.jar />
+    <org.apache.servicemix.bundles.aspectj-1.7.4_1.jar />
     <org.apache.servicemix.bundles.javax-inject-1_1.jar />
     <velocity-1.7.jar />
     <org.apache.servicemix.bundles.spring-core-${spring.version}.jar />

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -287,6 +287,12 @@
                 <version>1.0_6</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.servicemix.bundles</groupId>
+                <artifactId>org.apache.servicemix.bundles.aspectj</artifactId>
+                <version>1.7.4_1</version>
+                <scope>provided</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.sling</groupId>


### PR DESCRIPTION
In our project one of our bundles is using AspectJ aspects. This bundle often didn't start because of NoClassDefFoundErrors originating in the spring-aop bundle:

```
Caused by: org.springframework.beans.BeanInstantiationException: Could not instantiate bean class [org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator]: Constructor threw exception; nested exception is java.lang.NoClassDefFoundError: org/aspectj/lang/annotation/Around
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:163)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:87)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1032)
	... 36 common frames omitted
Caused by: java.lang.NoClassDefFoundError: org/aspectj/lang/annotation/Around
	at org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory.<clinit>(ReflectiveAspectJAdvisorFactory.java:74)
	at org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator.<init>(AnnotationAwareAspectJAutoProxyCreator.java:53)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:148)
	... 38 common frames omitted
Caused by: java.lang.ClassNotFoundException: org.aspectj.lang.annotation.Around not found by org.apache.servicemix.bundles.spring-aop [449]
	at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1557)
	at org.apache.felix.framework.BundleWiringImpl.access$400(BundleWiringImpl.java:79)
	at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:1998)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 45 common frames omitted
```

The import metadata is fine and my project's bundle starts perfectly if done manually. So I think the problem is that Neba provides spring-aop but not Aspectj which is an dependency of spring-aop which leads to some kind of race condition in Felix.

this pull request adds the AspectJ bundle to the Neba-provided bundles and it resolved the race condition in our project.