### PR TITLE
Add support for non-public @PreMapping/@PostMapping methods

### DIFF
--- a/api/src/main/java/io/neba/api/annotations/PostMapping.java
+++ b/api/src/main/java/io/neba/api/annotations/PostMapping.java
@@ -43,7 +43,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *              //...
  *          }
  *          &#064;{@link PostMapping}
- *          public void anotherMethodThatRequiresMappedProperties() throws Exception {
+ *          private void anotherMethodThatRequiresMappedProperties() throws Exception {
  *              ...
  *          }
  *     }

--- a/api/src/main/java/io/neba/api/annotations/PreMapping.java
+++ b/api/src/main/java/io/neba/api/annotations/PreMapping.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *              this.resource = ...;
  *          }
  *          &#064;{@link PreMapping}
- *          public void anotherMethodThatNeedsExecutionBeforeMapping() throws Exception {
+ *          private void anotherMethodThatNeedsExecutionBeforeMapping() throws Exception {
  *              ...
  *          }
  *     }

--- a/core/src/main/java/io/neba/core/resourcemodels/mapping/ModelProcessor.java
+++ b/core/src/main/java/io/neba/core/resourcemodels/mapping/ModelProcessor.java
@@ -41,9 +41,10 @@ public class ModelProcessor {
     public <T> void processAfterMapping(ResourceModelMetaData metaData, T model) {
         for (MethodMetaData methodMetaData : metaData.getPostMappingMethods()) {
             Method method = methodMetaData.getMethod();
+            method.setAccessible(true);
             try {
                 method.invoke(model);
-            } catch (InvocationTargetException e) {
+            } catch (InvocationTargetException | SecurityException e) {
                 logger.error("Unable to invoke the @" + PostMapping.class.getSimpleName() + " method " + method + ".", e);
             } catch (IllegalAccessException e) {
                 throw new IllegalStateException("It must not be illegal to access " + method + ".", e);
@@ -54,9 +55,10 @@ public class ModelProcessor {
     public <T> void processBeforeMapping(ResourceModelMetaData metaData, T model) {
         for (MethodMetaData methodMetaData : metaData.getPreMappingMethods()) {
             Method method = methodMetaData.getMethod();
+            method.setAccessible(true);
             try {
                 method.invoke(model);
-            } catch (InvocationTargetException e) {
+            } catch (InvocationTargetException | SecurityException e) {
                 logger.error("Unable to invoke the @" + PreMapping.class.getSimpleName() + " method " + method + ".", e);
             } catch (IllegalAccessException e) {
                 throw new IllegalStateException("It must not be illegal to access " + method + ".", e);

--- a/core/src/test/java/io/neba/core/resourcemodels/mapping/ModelProcessorTest.java
+++ b/core/src/test/java/io/neba/core/resourcemodels/mapping/ModelProcessorTest.java
@@ -43,13 +43,43 @@ public class ModelProcessorTest {
      */
     private class TestModel {
         @PostMapping
-        public void postMapping() {
-            setPostMappingCalled(true);
+        public void publicPostMapping() {
+            postMappingWasCalled();
+        }
+
+        @PostMapping
+        protected void protectedPostMapping() {
+            postMappingWasCalled();
+        }
+
+        @PostMapping
+        private void privatePostMapping() {
+            postMappingWasCalled();
+        }
+
+        @PostMapping
+        void packagePrivatePostMapping() {
+            postMappingWasCalled();
         }
 
         @PreMapping
         public void preMapping() {
-            setPreMappingCalled(true);
+            preMappingWasCalled();
+        }
+
+        @PreMapping
+        protected void protectedPreMapping() {
+            preMappingWasCalled();
+        }
+
+        @PreMapping
+        private void privatePreMapping() {
+            preMappingWasCalled();
+        }
+
+        @PreMapping
+        void packagePrivatePreMapping() {
+            preMappingWasCalled();
         }
     }
 
@@ -58,8 +88,8 @@ public class ModelProcessorTest {
     @Mock
     private Resource resource;
 
-    private boolean postMappingCalled;
-    private boolean preMappingCalled;
+    private int timesPostMappingCalled;
+    private int timesPreMappingCalled;
     private TestModel model;
     private ResourceModelMetaData metadata;
 
@@ -70,22 +100,24 @@ public class ModelProcessorTest {
     public void setUp() throws Exception {
         this.throwExceptionDuringPostMapping = false;
         this.throwExceptionDuringPreMapping = false;
+        this.timesPostMappingCalled = 0;
+        this.timesPreMappingCalled = 0;
     }
 
     @Test
     public void testPreMapping() throws Exception {
         withModel(new TestModel());
         processBeforeMapping();
-        assertPostMappingMethodIsNotInvoked();
-        assertPreMappingMethodIsInvoked();
+        assertPostMappingMethodsAreNotInvoked();
+        assertPreMappingMethodsAreInvoked();
     }
 
     @Test
     public void testPostMapping() throws Exception {
         withModel(new TestModel());
         processAfterMapping();
-        assertPreMappingMethodIsNotInvoked();
-        assertPostMappingMethodIsInvoked();
+        assertPreMappingMethodsAreNotInvoked();
+        assertPostMappingMethodsAreInvoked();
     }
 
     @Test
@@ -110,42 +142,34 @@ public class ModelProcessorTest {
         this.throwExceptionDuringPreMapping = true;
     }
 
-    public boolean isPostMappingCalled() {
-        return postMappingCalled;
-    }
-
-    public void setPostMappingCalled(boolean postMappingCalled) {
+    private void postMappingWasCalled() {
         if (throwExceptionDuringPostMapping) {
             throw new RuntimeException("THIS IS AN EXPECTED TEST EXCEPTION");
         }
-        this.postMappingCalled = postMappingCalled;
+        this.timesPostMappingCalled++;
     }
 
-    public boolean isPreMappingCalled() {
-        return preMappingCalled;
-    }
-
-    public void setPreMappingCalled(boolean preMappingCalled) {
+    private void preMappingWasCalled() {
         if (throwExceptionDuringPreMapping) {
             throw new RuntimeException("THIS IS AN EXPECTED TEST EXCEPTION");
         }
-        this.preMappingCalled = preMappingCalled;
+        this.timesPreMappingCalled++;
     }
 
-    private void assertPreMappingMethodIsNotInvoked() {
-        assertThat(this.preMappingCalled).isFalse();
+    private void assertPreMappingMethodsAreNotInvoked() {
+        assertThat(this.timesPreMappingCalled).isZero();
     }
 
-    private void assertPreMappingMethodIsInvoked() {
-        assertThat(this.preMappingCalled).isTrue();
+    private void assertPreMappingMethodsAreInvoked() {
+        assertThat(this.timesPreMappingCalled).isEqualTo(this.metadata.getPreMappingMethods().length);
     }
 
-    private void assertPostMappingMethodIsNotInvoked() {
-        assertThat(this.postMappingCalled).isFalse();
+    private void assertPostMappingMethodsAreNotInvoked() {
+        assertThat(this.timesPostMappingCalled).isZero();
     }
 
-    private void assertPostMappingMethodIsInvoked() {
-        assertThat(this.postMappingCalled).isTrue();
+    private void assertPostMappingMethodsAreInvoked() {
+        assertThat(this.timesPostMappingCalled).isEqualTo(this.metadata.getPostMappingMethods().length);
     }
 
     private void withModel(final TestModel testModel) {

--- a/core/src/test/java/io/neba/core/resourcemodels/mapping/ModelProcessorTest.java
+++ b/core/src/test/java/io/neba/core/resourcemodels/mapping/ModelProcessorTest.java
@@ -63,7 +63,7 @@ public class ModelProcessorTest {
         }
 
         @PreMapping
-        public void preMapping() {
+        public void publicPreMapping() {
             preMappingWasCalled();
         }
 


### PR DESCRIPTION
This addresses #106 by setting the method accessibility of `@PreMapping`/`@PostMapping` methods prior to invoking them.

My knowledge and experience with `java.lang.SecurityManager` is limited, but as I understand it there is a possibility for the manager to block requests to `setAccessible(true)`, but since this would be a runtime problem I thought it more appropriate to catch that exception and log the error along with the exception stack, rather than letting the exception bubble up or wrapping it in another exception.