### PR TITLE
neba-144 MVC: Enable view resolution to Sling Scripting

### DIFF
--- a/core/src/main/java/io/neba/core/mvc/BundleSpecificDispatcherServlet.java
+++ b/core/src/main/java/io/neba/core/mvc/BundleSpecificDispatcherServlet.java
@@ -1,21 +1,24 @@
-/**
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 the "License";
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- **/
+/*
+  Copyright 2013 the original author or authors.
+
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
 package io.neba.core.mvc;
 
+import io.neba.core.web.WebApplicationContextAdapter;
+import org.apache.sling.api.servlets.ServletResolver;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -53,10 +56,14 @@ import static org.springframework.beans.factory.BeanFactoryUtils.GENERATED_BEAN_
 public class BundleSpecificDispatcherServlet extends DispatcherServlet implements ApplicationListener<ApplicationEvent> {
     private final ServletConfig servletConfig;
     private final ConfigurableListableBeanFactory factory;
+    private final ServletResolver servletResolver;
 
     private boolean initialized = false;
 
-    public BundleSpecificDispatcherServlet(ServletConfig servletConfig, ConfigurableListableBeanFactory factory) {
+    public BundleSpecificDispatcherServlet(ServletConfig servletConfig,
+                                           ServletResolver servletResolver,
+                                           ConfigurableListableBeanFactory factory) {
+
         super();
         if (servletConfig == null) {
             throw new IllegalArgumentException("Constructor parameter servletConfig must not be null");
@@ -64,11 +71,15 @@ public class BundleSpecificDispatcherServlet extends DispatcherServlet implement
         if (factory == null) {
             throw new IllegalArgumentException("method parameter factory must not be null");
         }
+        if (servletResolver == null) {
+            throw new IllegalArgumentException("method parameter servletResolver must not be null");
+        }
 
         this.servletConfig = servletConfig;
         this.factory = factory;
+        this.servletResolver = servletResolver;
 
-        setPublishEvents(false);
+        setPublishEvents(true);
         setDispatchOptionsRequest(true);
         setDispatchTraceRequest(true);
     }
@@ -82,6 +93,9 @@ public class BundleSpecificDispatcherServlet extends DispatcherServlet implement
     public void onApplicationEvent(ApplicationEvent event) {
         if (event instanceof ContextRefreshedEvent) {
             synchronized (this) {
+                ApplicationContext applicationContext = ((ContextRefreshedEvent) event).getApplicationContext();
+                setApplicationContext(new WebApplicationContextAdapter(applicationContext, this.servletConfig.getServletContext()));
+
                 // Configure the MVC infrastructure
                 configureMultipartResolver();
                 configureExceptionResolvers();
@@ -91,7 +105,7 @@ public class BundleSpecificDispatcherServlet extends DispatcherServlet implement
                 addNebaViewResolver();
 
                 // Picks up the previously registered MVC infrastructure
-                onRefresh(((ContextRefreshedEvent) event).getApplicationContext());
+                onRefresh(applicationContext);
 
                 this.initialized = true;
             }
@@ -168,7 +182,9 @@ public class BundleSpecificDispatcherServlet extends DispatcherServlet implement
     }
 
     private void addNebaViewResolver() {
-        defineBean(NebaViewResolver.class);
+        this.factory.registerSingleton(
+                generateBeanNameFor(NebaViewResolver.class),
+                new NebaViewResolver(this.servletResolver));
     }
 
     /**

--- a/core/src/main/java/io/neba/core/mvc/NebaViewResolver.java
+++ b/core/src/main/java/io/neba/core/mvc/NebaViewResolver.java
@@ -1,35 +1,49 @@
-/**
- * Copyright 2013 the original author or authors.
- * 
- * Licensed under the Apache License, Version 2.0 the "License";
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
+/*
+  Copyright 2013 the original author or authors.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-**/
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
 package io.neba.core.mvc;
 
+import org.apache.sling.api.SlingException;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.servlets.ServletResolver;
+import org.springframework.core.Ordered;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.view.InternalResourceView;
 
+import javax.servlet.Servlet;
 import java.util.Locale;
 
+import static java.lang.Integer.MAX_VALUE;
+import static org.springframework.web.context.request.RequestContextHolder.getRequestAttributes;
+import static org.springframework.web.servlet.view.UrlBasedViewResolver.FORWARD_URL_PREFIX;
+import static org.springframework.web.servlet.view.UrlBasedViewResolver.REDIRECT_URL_PREFIX;
+
 /**
- * Supports "redirect:" and "forward:" {@link View} resolution from view name.
+ * Supports "redirect:" and "forward:" views and falls back to eh {@link SlingServletView} for a provided view name.
  *
  * @author Olaf Otto
  */
-public class NebaViewResolver implements ViewResolver {
-    public static final String REDIRECT_URL_PREFIX = "redirect:";
-    public static final String FORWARD_URL_PREFIX = "forward:";
+public class NebaViewResolver implements ViewResolver, Ordered {
+    private final ServletResolver servletResolver;
+
+    public NebaViewResolver(ServletResolver servletResolver) {
+        this.servletResolver = servletResolver;
+    }
 
     /**
      * Resolves a {@link View} from the provided view name.
@@ -46,10 +60,61 @@ public class NebaViewResolver implements ViewResolver {
             String redirectUrl = viewName.substring(REDIRECT_URL_PREFIX.length());
             return new SlingRedirectView(redirectUrl, true, true);
         }
+
         if (viewName.startsWith(FORWARD_URL_PREFIX)) {
             String forwardUrl = viewName.substring(FORWARD_URL_PREFIX.length());
             return new InternalResourceView(forwardUrl);
         }
+
+        return resolveScriptingView(viewName);
+    }
+
+    private SlingServletView resolveScriptingView(String resourceType) {
+        final ResourceResolver resourceResolver = ((SlingHttpServletRequest) ((ServletRequestAttributes) getRequestAttributes()).getRequest()).getResourceResolver();
+
+        // Support script inheritance by traversing the type hierarchy of the resource.
+        // The type hierarchy is also traversed by the Servlet Resolver, but the resolver
+        // only does this compliant to the Sling Script resolution when invoked with a HTTP request.
+        // However, invocation with a request relies on an undocumented and unstable API contract,
+        // depending, amongst others, on the HTTP method, request path, suffix, selector and extension
+        // of the request path, which cannot be leveraged for controller responses.
+        // Thus, the script is resolved explicitly.
+        String currentResourceType = resourceType;
+
+        do {
+            int separatorPos = currentResourceType.lastIndexOf('/');
+            if (separatorPos != -1) {
+                // Since the view resolution is not sensitive to request state, resolve the default view name
+                // for a resource type, e.g. "myType" in app/components/myType, for instance app/components/myType/myType.html
+                String defaultScriptName = currentResourceType.substring(separatorPos);
+                Servlet servlet = getServlet(resourceResolver, currentResourceType, defaultScriptName);
+                if (servlet != null) {
+                    return new SlingServletView(resourceType, servlet);
+                }
+            }
+            currentResourceType = resourceResolver.getParentResourceType(currentResourceType);
+        } while (currentResourceType != null);
+
         return null;
+    }
+
+    private Servlet getServlet(ResourceResolver resourceResolver, String type, String defaultScriptName) {
+        try {
+            return servletResolver.resolveServlet(resourceResolver, type + defaultScriptName);
+        } catch (SlingException e) {
+            // Ignore as this is expected for nonexistent scripts as per API contract
+            return null;
+        }
+    }
+
+    /**
+     * Multiple view resolvers may coexist and are prioritized via implementation of {@link Ordered}.
+     * Spring's {@link org.springframework.web.servlet.view.InternalResourceViewResolver} has the lowest priority
+     * {@link Integer#MAX_VALUE}. This view resolver shall have a higher priority, but allow for any
+     * custom view resolvers to override it.
+     */
+    @Override
+    public int getOrder() {
+        return MAX_VALUE - 1;
     }
 }

--- a/core/src/main/java/io/neba/core/mvc/SlingMvcServletRequest.java
+++ b/core/src/main/java/io/neba/core/mvc/SlingMvcServletRequest.java
@@ -1,24 +1,27 @@
-/**
- * Copyright 2013 the original author or authors.
- * 
- * Licensed under the Apache License, Version 2.0 the "License";
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
+/*
+  Copyright 2013 the original author or authors.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-**/
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 
 package io.neba.core.mvc;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.request.RequestPathInfo;
 import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+
+import static org.springframework.web.util.WebUtils.INCLUDE_REQUEST_URI_ATTRIBUTE;
+import static org.springframework.web.util.WebUtils.INCLUDE_SERVLET_PATH_ATTRIBUTE;
 
 /**
  * Provides the actual path of the MVC servlet through {@link #getServletPath()} to enable
@@ -30,6 +33,17 @@ import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
 public class SlingMvcServletRequest extends SlingHttpServletRequestWrapper {
     public SlingMvcServletRequest(SlingHttpServletRequest request) {
         super(request);
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        if (INCLUDE_REQUEST_URI_ATTRIBUTE.equals(name)) {
+            return getServletPath() + getRequestPathInfo().getSuffix();
+        }
+        if (INCLUDE_SERVLET_PATH_ATTRIBUTE.equals(name)) {
+            return getServletPath();
+        }
+        return super.getAttribute(name);
     }
 
     @Override

--- a/core/src/main/java/io/neba/core/mvc/SlingServletView.java
+++ b/core/src/main/java/io/neba/core/mvc/SlingServletView.java
@@ -1,0 +1,92 @@
+/*
+  Copyright 2013 the original author or authors.
+
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package io.neba.core.mvc;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.SyntheticResource;
+import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+import org.springframework.web.servlet.View;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+/**
+ * Resolves a resource path to a {@link Servlet} representing a {@link org.apache.sling.api.scripting.SlingScript}
+ * and invokes the script to {@link #render(Map, HttpServletRequest, HttpServletResponse) render} the view.
+ *
+ * @author Olaf Otto
+ */
+public class SlingServletView implements View {
+    private final String resourceType;
+    private final Servlet servlet;
+
+    public SlingServletView(String resourceType, Servlet servlet) {
+        this.resourceType = resourceType;
+        this.servlet = servlet;
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    /**
+     * @param model    can be <code>null</code>.
+     * @param request  must not be <code>null</code>.
+     * @param response must not be <code>null</code>.
+     */
+    @Override
+    public void render(Map<String, ?> model, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        final SlingHttpServletRequest slingRequest = (SlingHttpServletRequest) request;
+        final ResourceResolver resourceResolver = slingRequest.getResourceResolver();
+        final String resourcePath = request.getPathInfo();
+
+        final Resource resource = new SyntheticResource(resourceResolver, resourcePath, this.resourceType);
+        final SlingHttpServletRequest wrapped = new MvcResourceRequest(slingRequest, resource);
+
+        if (model != null) {
+            for (Map.Entry<String, ?> entry : model.entrySet()) {
+                wrapped.setAttribute(entry.getKey(), entry.getValue());
+            }
+        }
+
+        servlet.service(wrapped, response);
+    }
+
+    /**
+     * Wraps the original controller request to provide a {@link java.util.ResourceBundle.Control} as the
+     * {@link #getResource() request's resource}.
+     *
+     * @author Olaf Otto
+     */
+    static class MvcResourceRequest extends SlingHttpServletRequestWrapper {
+        private final Resource resource;
+
+        MvcResourceRequest(SlingHttpServletRequest slingRequest, Resource resource) {
+            super(slingRequest);
+            this.resource = resource;
+        }
+
+        @Override
+        public Resource getResource() {
+            return resource;
+        }
+    }
+}

--- a/core/src/main/java/io/neba/core/web/WebApplicationContextAdapter.java
+++ b/core/src/main/java/io/neba/core/web/WebApplicationContextAdapter.java
@@ -1,0 +1,253 @@
+/*
+  Copyright 2013 the original author or authors.
+
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package io.neba.core.web;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.NoSuchMessageException;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.Resource;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.servlet.ServletContext;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * @author Olaf Otto
+ */
+public class WebApplicationContextAdapter implements WebApplicationContext {
+    private final ApplicationContext wrapped;
+    private final ServletContext servletContext;
+
+    public WebApplicationContextAdapter(ApplicationContext wrapped, ServletContext servletContext) {
+        this.wrapped = wrapped;
+        this.servletContext = servletContext;
+    }
+
+    @Override
+    public String getId() {
+        return wrapped.getId();
+    }
+
+    @Override
+    public String getApplicationName() {
+        return wrapped.getApplicationName();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return wrapped.getDisplayName();
+    }
+
+    @Override
+    public long getStartupDate() {
+        return wrapped.getStartupDate();
+    }
+
+    @Override
+    public ApplicationContext getParent() {
+        return wrapped.getParent();
+    }
+
+    @Override
+    public AutowireCapableBeanFactory getAutowireCapableBeanFactory() throws IllegalStateException {
+        return wrapped.getAutowireCapableBeanFactory();
+    }
+
+    @Override
+    public Environment getEnvironment() {
+        return wrapped.getEnvironment();
+    }
+
+    @Override
+    public boolean containsBeanDefinition(String beanName) {
+        return wrapped.containsBeanDefinition(beanName);
+    }
+
+    @Override
+    public int getBeanDefinitionCount() {
+        return wrapped.getBeanDefinitionCount();
+    }
+
+    @Override
+    public String[] getBeanDefinitionNames() {
+        return wrapped.getBeanDefinitionNames();
+    }
+
+    @Override
+    public String[] getBeanNamesForType(ResolvableType type) {
+        return wrapped.getBeanNamesForType(type);
+    }
+
+    @Override
+    public String[] getBeanNamesForType(Class<?> type) {
+        return wrapped.getBeanNamesForType(type);
+    }
+
+    @Override
+    public String[] getBeanNamesForType(Class<?> type, boolean includeNonSingletons, boolean allowEagerInit) {
+        return wrapped.getBeanNamesForType(type, includeNonSingletons, allowEagerInit);
+    }
+
+    @Override
+    public <T> Map<String, T> getBeansOfType(Class<T> type) throws BeansException {
+        return wrapped.getBeansOfType(type);
+    }
+
+    @Override
+    public <T> Map<String, T> getBeansOfType(Class<T> type, boolean includeNonSingletons, boolean allowEagerInit) throws BeansException {
+        return wrapped.getBeansOfType(type, includeNonSingletons, allowEagerInit);
+    }
+
+    @Override
+    public String[] getBeanNamesForAnnotation(Class<? extends Annotation> annotationType) {
+        return wrapped.getBeanNamesForAnnotation(annotationType);
+    }
+
+    @Override
+    public Map<String, Object> getBeansWithAnnotation(Class<? extends Annotation> annotationType) throws BeansException {
+        return wrapped.getBeansWithAnnotation(annotationType);
+    }
+
+    @Override
+    public <A extends Annotation> A findAnnotationOnBean(String beanName, Class<A> annotationType) throws NoSuchBeanDefinitionException {
+        return wrapped.findAnnotationOnBean(beanName, annotationType);
+    }
+
+    @Override
+    public Object getBean(String name) throws BeansException {
+        return wrapped.getBean(name);
+    }
+
+    @Override
+    public <T> T getBean(String name, Class<T> requiredType) throws BeansException {
+        return wrapped.getBean(name, requiredType);
+    }
+
+    @Override
+    public <T> T getBean(Class<T> requiredType) throws BeansException {
+        return wrapped.getBean(requiredType);
+    }
+
+    @Override
+    public Object getBean(String name, Object... args) throws BeansException {
+        return wrapped.getBean(name, args);
+    }
+
+    @Override
+    public <T> T getBean(Class<T> requiredType, Object... args) throws BeansException {
+        return wrapped.getBean(requiredType, args);
+    }
+
+    @Override
+    public boolean containsBean(String name) {
+        return wrapped.containsBean(name);
+    }
+
+    @Override
+    public boolean isSingleton(String name) throws NoSuchBeanDefinitionException {
+        return wrapped.isSingleton(name);
+    }
+
+    @Override
+    public boolean isPrototype(String name) throws NoSuchBeanDefinitionException {
+        return wrapped.isPrototype(name);
+    }
+
+    @Override
+    public boolean isTypeMatch(String name, ResolvableType typeToMatch) throws NoSuchBeanDefinitionException {
+        return wrapped.isTypeMatch(name, typeToMatch);
+    }
+
+    @Override
+    public boolean isTypeMatch(String name, Class<?> typeToMatch) throws NoSuchBeanDefinitionException {
+        return wrapped.isTypeMatch(name, typeToMatch);
+    }
+
+    @Override
+    public Class<?> getType(String name) throws NoSuchBeanDefinitionException {
+        return wrapped.getType(name);
+    }
+
+    @Override
+    public String[] getAliases(String name) {
+        return wrapped.getAliases(name);
+    }
+
+    @Override
+    public BeanFactory getParentBeanFactory() {
+        return wrapped.getParentBeanFactory();
+    }
+
+    @Override
+    public boolean containsLocalBean(String name) {
+        return wrapped.containsLocalBean(name);
+    }
+
+    @Override
+    public String getMessage(String code, Object[] args, String defaultMessage, Locale locale) {
+        return wrapped.getMessage(code, args, defaultMessage, locale);
+    }
+
+    @Override
+    public String getMessage(String code, Object[] args, Locale locale) throws NoSuchMessageException {
+        return wrapped.getMessage(code, args, locale);
+    }
+
+    @Override
+    public String getMessage(MessageSourceResolvable resolvable, Locale locale) throws NoSuchMessageException {
+        return wrapped.getMessage(resolvable, locale);
+    }
+
+    @Override
+    public void publishEvent(ApplicationEvent event) {
+        wrapped.publishEvent(event);
+    }
+
+    @Override
+    public void publishEvent(Object event) {
+        wrapped.publishEvent(event);
+    }
+
+    @Override
+    public Resource[] getResources(String locationPattern) throws IOException {
+        return wrapped.getResources(locationPattern);
+    }
+
+    @Override
+    public Resource getResource(String location) {
+        return wrapped.getResource(location);
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return wrapped.getClassLoader();
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return this.servletContext;
+    }
+}

--- a/core/src/main/resources/META-INF/spring/extender/context.xml
+++ b/core/src/main/resources/META-INF/spring/extender/context.xml
@@ -43,6 +43,8 @@
 
 		<bp:reference interface="javax.servlet.ServletConfig" id="servletConfig" />
 
+		<bp:reference interface="org.apache.sling.api.servlets.ServletResolver" id="servletResolver" />
+
 		<!-- All post processors are used by the mapper -->
 		<bp:reference-list interface="io.neba.api.resourcemodels.ResourceModelPostProcessor" availability="optional">
 			<bp:reference-listener ref="resourceToModelMapper" bind-method="bind" unbind-method="unbind" />
@@ -138,7 +140,7 @@
 		<bp:service ref="mappableTypeHierarchyChangeListener" interface="org.osgi.service.event.EventHandler">
 			<bp:service-properties>
 				<entry key="event.topics" value="org/apache/sling/api/resource/Resource/CHANGED"/>
-				<!-- React to changes potentially altering the resource type hierarchy, unless they are occurring
+				<!-- React to changes potentially altering the cacheable resource type hierarchy, unless they are occurring
 				     in a location known not to contain data relevant to the type hierarchy, such as /var or /content -->
 				<entry key="event.filter" value="(&amp;
 				 (!(path=/content/*))

--- a/core/src/test/java/io/neba/core/mvc/BundleSpecificDispatcherServletTest.java
+++ b/core/src/test/java/io/neba/core/mvc/BundleSpecificDispatcherServletTest.java
@@ -1,22 +1,24 @@
-/**
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 the "License";
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+/*
+  Copyright 2013 the original author or authors.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- **/
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
 
 package io.neba.core.mvc;
 
+import io.neba.core.web.WebApplicationContextAdapter;
 import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.ServletResolver;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -76,6 +78,8 @@ public class BundleSpecificDispatcherServletTest {
     @Mock
     private ServletConfig servletConfig;
     @Mock
+    private ServletResolver servletResolver;
+    @Mock
     private SlingMvcServletRequest request;
     @Mock
     private SlingHttpServletResponse response;
@@ -99,17 +103,43 @@ public class BundleSpecificDispatcherServletTest {
         };
         doAnswer(createMock).when(this.factory).createBean(isA(Class.class));
 
-        this.testee = new BundleSpecificDispatcherServlet(this.servletConfig, this.factory);
+        this.testee = new BundleSpecificDispatcherServlet(this.servletConfig, this.servletResolver, this.factory);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testHandlingOfNullFactoryInConstructor() throws Exception {
-        new BundleSpecificDispatcherServlet(mock(ServletConfig.class), null);
+        new BundleSpecificDispatcherServlet(mock(ServletConfig.class), this.servletResolver, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testHandlingOfNullServletConfigInConstructor() throws Exception {
-        new BundleSpecificDispatcherServlet(null, mock(ConfigurableListableBeanFactory.class));
+        new BundleSpecificDispatcherServlet(null, this.servletResolver, mock(ConfigurableListableBeanFactory.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHandlingOfNullServletResolverInConstructor() throws Exception {
+        new BundleSpecificDispatcherServlet(mock(ServletConfig.class), null, mock(ConfigurableListableBeanFactory.class));
+    }
+
+    @Test
+    public void testApplicationContextIsProvidedAsWebApplicationContext() throws Exception {
+        signalContextRefreshed();
+        assertDispatcherServletIsInitializedWithWebApplicationContextAdapter();
+    }
+
+    @Test
+    public void testWebApplicationContextDispatchesToOriginalApplicationContext() throws Exception {
+        signalContextRefreshed();
+        getBeanFromWebApplicationContext("anyBean");
+        verifyBeanIsFetchedFromApplicationContext("anyBean");
+    }
+
+    private void verifyBeanIsFetchedFromApplicationContext(String beanName) {
+        verify(this.applicationContext).getBean(beanName);
+    }
+
+    private void getBeanFromWebApplicationContext(String beanName) {
+        this.testee.getWebApplicationContext().getBean(beanName);
     }
 
     @Test
@@ -266,12 +296,43 @@ public class BundleSpecificDispatcherServletTest {
         verifyHandlerMappingIsUsedForRequest();
     }
 
+    @Test
+    public void testHasHandlerForIsAlwaysFalseWhenServletIsNotInitialized() throws Exception {
+        withExistingHandlerMapping();
+
+        assertServletHasNoHandlerForRequest();
+
+        verifyHandlerMappingIsNotUsedForRequest();
+    }
+
+    @Test
+    public void testHasHandlerForRequestChecksHandlerMappingsWhenServletIsInitialized() throws Exception {
+        withExistingHandlerMapping();
+        signalContextRefreshed();
+
+        assertServletHasHandlerForRequest();
+
+        verifyHandlerMappingIsUsedForRequest();
+    }
+
+    private void assertServletHasHandlerForRequest() {
+        assertThat(this.testee.hasHandlerFor(this.request)).isTrue();
+    }
+
+    private void assertServletHasNoHandlerForRequest() {
+        assertThat(this.testee.hasHandlerFor(this.request)).isFalse();
+    }
+
     private void withResponseContentType(String type) {
         doReturn(type).when(this.response).getContentType();
     }
 
     private void verifyHandlerMappingIsUsedForRequest() throws Exception {
         verify(this.handlerMapping).getHandler(eq(this.request));
+    }
+
+    private void verifyHandlerMappingIsNotUsedForRequest() throws Exception {
+        verify(this.handlerMapping, never()).getHandler(eq(this.request));
     }
 
     private void withExistingHandlerMapping() {
@@ -340,7 +401,7 @@ public class BundleSpecificDispatcherServletTest {
     }
 
     private void verifyViewResolverIsRegistered() {
-        verifyContextDefinesBean(NebaViewResolver.class);
+        verify(this.factory).registerSingleton(anyString(), isA(NebaViewResolver.class));
     }
 
     private void verifyHandlerMappingsAreRegistered() {
@@ -404,6 +465,10 @@ public class BundleSpecificDispatcherServletTest {
 
     private void signalContextRefreshed() {
         this.testee.onApplicationEvent((ApplicationEvent) this.event);
+    }
+
+    private void assertDispatcherServletIsInitializedWithWebApplicationContextAdapter() {
+        assertThat(this.testee.getWebApplicationContext()).isInstanceOf(WebApplicationContextAdapter.class);
     }
 
     private <T> T mockExistingBean(final Class<T> beanType) {

--- a/core/src/test/java/io/neba/core/mvc/NebaViewResolverTest.java
+++ b/core/src/test/java/io/neba/core/mvc/NebaViewResolverTest.java
@@ -1,21 +1,26 @@
-/**
- * Copyright 2013 the original author or authors.
- * 
- * Licensed under the Apache License, Version 2.0 the "License";
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
+/*
+  Copyright 2013 the original author or authors.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-**/
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 
 package io.neba.core.mvc;
 
+import org.apache.sling.api.SlingException;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.servlets.ServletResolver;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,22 +28,27 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.FlashMapManager;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.view.InternalResourceView;
+import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.RequestDispatcher;
+import javax.servlet.Servlet;
 import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 
+import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
+import static org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes;
+import static org.springframework.web.context.request.RequestContextHolder.setRequestAttributes;
 import static org.springframework.web.servlet.DispatcherServlet.FLASH_MAP_MANAGER_ATTRIBUTE;
 
 /**
@@ -47,13 +57,17 @@ import static org.springframework.web.servlet.DispatcherServlet.FLASH_MAP_MANAGE
 @RunWith(MockitoJUnitRunner.class)
 public class NebaViewResolverTest {
     @Mock
-    private HttpServletRequest request;
-    @Mock
-    private RequestDispatcher dispatcher;
+    private SlingHttpServletRequest request;
     @Mock
     private HttpServletResponse response;
     @Mock
+    private ResourceResolver resourceResolver;
+    @Mock
+    private RequestDispatcher dispatcher;
+    @Mock
     private FlashMapManager flashMapManager;
+    @Mock
+    private ServletResolver servletResolver;
 
     private View resolvedView;
 
@@ -65,14 +79,33 @@ public class NebaViewResolverTest {
         doReturn("").when(this.request).getContextPath();
         doReturn(this.dispatcher).when(this.request).getRequestDispatcher(anyString());
         doReturn(this.flashMapManager).when(this.request).getAttribute(FLASH_MAP_MANAGER_ATTRIBUTE);
+        doReturn(this.resourceResolver).when(this.request).getResourceResolver();
+
         Answer<Object> original = invocation -> invocation.getArguments()[0];
         doAnswer(original).when(this.response).encodeRedirectURL(anyString());
+        setRequestAttributes(new ServletRequestAttributes(this.request));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetRequestAttributes();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullViewNamesAreNotTolerated() throws Exception {
+        this.testee.resolveViewName(null, ENGLISH);
+    }
+
+    @Test
+    public void testNullLocaleIstTolerated() throws Exception {
+        this.testee.resolveViewName("viewName", null);
     }
 
     @Test
     public void testResolutionOfRedirectView() throws Exception {
         resolve("redirect:/test/me");
         assertViewHasType(RedirectView.class);
+
         renderView();
         verifyViewRedirectsTo("/test/me");
     }
@@ -81,8 +114,99 @@ public class NebaViewResolverTest {
     public void testResolutionOfForwardView() throws Exception {
         resolve("forward:/test/me");
         assertViewHasType(InternalResourceView.class);
+
         renderView();
         verifyViewForwardsTo("/test/me");
+    }
+
+    /**
+     * When a {@link org.springframework.web.servlet.ViewResolver} cannot provide a view, it must return null
+     * to allow other view resolvers to provide a view.
+     */
+    @Test
+    public void testUnresolvableViewYieldsNull() throws Exception {
+        resolve("nonexistent/view");
+        assertViewIsNull();
+    }
+
+    /**
+     * When a controller returns a resource type that has a default script, such as
+     * app/components/myComponents/myComponent.jsp, the view resolver shall provide
+     * a view for this script.
+     */
+    @Test
+    public void testResolutionOfSlingScriptWithoutInheritance() throws Exception {
+        withDefaultScriptForType("app/components/myComponent");
+
+        resolve("app/components/myComponent");
+
+        verifyViewResolverResolvesScript("app/components/myComponent/myComponent");
+        assertViewHasType(SlingServletView.class);
+    }
+
+    /**
+     * When there is no default sling script for the resource type returned
+     * by a controller, and the resource type has a {@link ResourceResolver#getParentResourceType(String) parent resource type},
+     * the view resolver must attempt to resolve the default script for the super type.s
+     */
+    @Test
+    public void testResolutionOfInheritedSlingScript() throws Exception {
+        withSuperType("app/components/myComponent", "app/components/superType");
+        withDefaultScriptForType("app/components/superType");
+
+        resolve("app/components/myComponent");
+
+        verifyViewResolverResolvesScript("app/components/myComponent/myComponent");
+        verifyViewResolverResolvesScript("app/components/superType/superType");
+        assertViewHasType(SlingServletView.class);
+    }
+
+    /**
+     * The {@link ServletResolver} may throw a {@link SlingException} when a script cannot be resolved,
+     * which must be tolerated and result in no view.
+     */
+    @Test
+    public void testHandlingOfSlingExceptionDuringServletResolution() throws Exception {
+        withExceptionDuringServletResolution();
+
+        resolve("some/type");
+
+        assertViewIsNull();
+    }
+
+    /**
+     * View resolvers are  {@link org.springframework.core.Ordered}. NEBA's resource resolver shall be a fallback with higher
+     * order than Spring's default {@link InternalResourceViewResolver} to override it but allow overriding by custom, higher-ranking
+     * view resolvers.
+     */
+    @Test
+    public void testNebaViewResolverOrderIsDirectlyAboveSpringsDefaultResolverOrder() throws Exception {
+        assertThat(this.testee.getOrder()).isEqualTo(new InternalResourceViewResolver().getOrder() - 1);
+    }
+
+    private void withExceptionDuringServletResolution() {
+        doThrow(mock(SlingException.class)).when(this.servletResolver).resolveServlet(eq(this.resourceResolver), anyString());
+    }
+
+    private void withSuperType(String resourceType, String resourceSuperType) {
+        doReturn(resourceSuperType).when(this.resourceResolver).getParentResourceType(resourceType);
+    }
+
+    private void verifyViewResolverResolvesScript(String scriptPath) {
+        verify(this.servletResolver).resolveServlet(this.resourceResolver, scriptPath);
+    }
+
+    private void withDefaultScriptForType(String resourceType) {
+        Servlet script = mock(Servlet.class);
+        doReturn(script)
+                .when(this.servletResolver)
+                .resolveServlet(
+                        this.resourceResolver,
+                        resourceType + resourceType.substring(resourceType.lastIndexOf('/')));
+    }
+
+    private void assertViewIsNull() {
+        assertThat(this.resolvedView).isNull();
     }
 
     private void verifyViewForwardsTo(String url) throws ServletException, IOException {

--- a/core/src/test/java/io/neba/core/mvc/SlingMvcServletRequestTest.java
+++ b/core/src/test/java/io/neba/core/mvc/SlingMvcServletRequestTest.java
@@ -1,18 +1,18 @@
-/**
- * Copyright 2013 the original author or authors.
- * 
- * Licensed under the Apache License, Version 2.0 the "License";
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
+/*
+  Copyright 2013 the original author or authors.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
-**/
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 
 package io.neba.core.mvc;
 
@@ -26,6 +26,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.springframework.web.util.WebUtils.INCLUDE_REQUEST_URI_ATTRIBUTE;
+import static org.springframework.web.util.WebUtils.INCLUDE_SERVLET_PATH_ATTRIBUTE;
 
 /**
  * @author Olaf Otto
@@ -44,6 +47,7 @@ public class SlingMvcServletRequestTest {
         doReturn(this.requestPathInfo).when(this.request).getRequestPathInfo();
         doReturn("/bin/mvc").when(this.requestPathInfo).getResourcePath();
         doReturn("do").when(this.requestPathInfo).getExtension();
+        doReturn("/controllerPath").when(this.requestPathInfo).getSuffix();
 
         this.testee = new SlingMvcServletRequest(this.request);
     }
@@ -51,5 +55,43 @@ public class SlingMvcServletRequestTest {
     @Test
     public void testMvcRequestProvidesServletResourcePathAndExtensionAsServletPath() throws Exception {
         assertThat(this.testee.getServletPath()).isEqualTo("/bin/mvc.do");
+    }
+
+    /**
+     * By default, sling provides the original request's servlet path, even if
+     * a completely different path was included. For instance, a request to
+     * "/test.html" with a subsequent &lt;sling:include path="/other/path"&gt; will
+     * yield the include path "".
+     *
+     * Test that the {@link SlingMvcServletRequest} overrides this behavior, providing
+     * the actually included servlet path. This allows including MVC resources, e.g.
+     * &lt;sling:include path="/bin/mvc.do/controller"&gt;
+     */
+    @Test
+    public void testIncludeServletPathIsSameAsServletPath() throws Exception {
+        assertThat(this.testee.getAttribute(INCLUDE_SERVLET_PATH_ATTRIBUTE))
+                .isEqualTo("/bin/mvc.do");
+    }
+
+    /**
+     * By default, sling provides the original request's URI, even if
+     * a completely different URI was included. For instance, a request to
+     * "/test.html" with a subsequent &lt;sling:include path="/servlet/path"&gt; will
+     * yield the include URI path "/test.html".
+     *
+     * Test that the {@link SlingMvcServletRequest} overrides this behavior, providing
+     * the actually included URI. This allows including MVC resources, e.g.
+     * &lt;sling:include path="/bin/mvc.do/controller"&gt;
+     */
+    @Test
+    public void testIncludeContextPathIsSameAsServletPath() throws Exception {
+        assertThat(this.testee.getAttribute(INCLUDE_REQUEST_URI_ATTRIBUTE))
+                .isEqualTo("/bin/mvc.do/controllerPath");
+    }
+
+    @Test
+    public void testOtherAttributesAreFetchedFromTheOriginalRequest() throws Exception {
+        this.testee.getAttribute("other.attribute");
+        verify(this.request).getAttribute("other.attribute");
     }
 }

--- a/core/src/test/java/io/neba/core/mvc/SlingServletViewTest.java
+++ b/core/src/test/java/io/neba/core/mvc/SlingServletViewTest.java
@@ -1,0 +1,130 @@
+/*
+  Copyright 2013 the original author or authors.
+
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package io.neba.core.mvc;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Olaf Otto
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SlingServletViewTest {
+    @Mock
+    private SlingHttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+    @Mock
+    private ResourceResolver resourceResolver;
+    @Mock
+    private Servlet script;
+
+    private Resource resourceProvidedToScript;
+
+    private SlingServletView testee;
+
+    @Before
+    public void setUp() throws Exception {
+        when(this.request.getResourceResolver()).thenReturn(this.resourceResolver);
+        when(this.request.getPathInfo()).thenReturn("/bin/mvc.do/controller/path");
+
+        doAnswer(
+                invocation ->
+                        resourceProvidedToScript = ((SlingHttpServletRequest) invocation.getArguments()[0]).getResource())
+                .when(this.script)
+                .service(isA(SlingServletView.MvcResourceRequest.class), eq(this.response));
+
+        this.testee = new SlingServletView("some/resource/type", this.script);
+    }
+
+    @Test
+    public void testViewToleratesNullModel() throws Exception {
+        renderViewWithModel(null);
+        verifyScriptIsInvoked();
+    }
+
+    @Test
+    public void testViewDoesNotDefineContentTypeInAdvance() throws Exception {
+        assertThat(this.testee.getContentType()).isNull();
+    }
+
+    @Test
+    public void testViewProvidesModelEntriesAsRequestAttributes() throws Exception {
+        Map<String, Object> model = new HashMap<>();
+        model.put("key", "value");
+
+        renderViewWithModel(model);
+
+        verifyRequestAttributeIsSet("key", "value");
+        verifyScriptIsInvoked();
+    }
+
+    @Test
+    public void testViewProvidesScriptWithResourceRepresentingViewResourceType() throws Exception {
+        renderViewWithModel(null);
+
+        assertResourceIsProvidedToScript();
+        assertResourceTypeIs("some/resource/type");
+        assertResourceResolverIs(this.resourceResolver);
+        assertResourcePathIs("/bin/mvc.do/controller/path");
+    }
+
+    private void assertResourcePathIs(String path) {
+        assertThat(this.resourceProvidedToScript.getPath()).isEqualTo(path);
+    }
+
+    private void assertResourceResolverIs(ResourceResolver resourceResolver) {
+        assertThat(this.resourceProvidedToScript.getResourceResolver()).isEqualTo(resourceResolver);
+    }
+
+    private void assertResourceTypeIs(String type) {
+        assertThat(this.resourceProvidedToScript.getResourceType()).isEqualTo(type);
+    }
+
+    private void assertResourceIsProvidedToScript() {
+        assertThat(this.resourceProvidedToScript).isNotNull();
+    }
+
+    private void verifyRequestAttributeIsSet(String key, String value) {
+        verify(this.request).setAttribute(key, value);
+    }
+
+    private void verifyScriptIsInvoked() throws ServletException, IOException {
+        verify(this.script).service(isA(SlingServletView.MvcResourceRequest.class), eq(this.response));
+    }
+
+    private void renderViewWithModel(Map<String, ?> model) throws Exception {
+        this.testee.render(model, this.request, this.response);
+    }
+}

--- a/core/src/test/java/io/neba/core/web/WebApplicationContextAdapterTest.java
+++ b/core/src/test/java/io/neba/core/web/WebApplicationContextAdapterTest.java
@@ -1,0 +1,92 @@
+/*
+  Copyright 2013 the original author or authors.
+
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package io.neba.core.web;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.springframework.context.ApplicationContext;
+
+import javax.servlet.ServletContext;
+import java.lang.reflect.Method;
+
+import static java.util.Arrays.stream;
+import static org.apache.commons.lang3.StringUtils.join;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Olaf Otto
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebApplicationContextAdapterTest {
+    @Mock
+    private ServletContext servletContext;
+
+    private InvocationOnMock lastInvocationOnWrappedContext;
+
+    private WebApplicationContextAdapter testee;
+
+    @Before
+    public void setUp() throws Exception {
+        ApplicationContext applicationContext = mock(ApplicationContext.class, new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                lastInvocationOnWrappedContext = invocation;
+                return null;
+            }
+        });
+
+        this.testee = new WebApplicationContextAdapter(applicationContext, this.servletContext);
+    }
+
+    @Test
+    public void testAllWrappedMethodsDelegateToTheirWrappedEquivalents() throws Exception {
+        for (Method method : ApplicationContext.class.getMethods()) {
+            method.invoke(this.testee, mockArgs(method));
+            if (lastInvocationOnWrappedContext == null ||
+                    !signatureOf(lastInvocationOnWrappedContext.getMethod()).equals(signatureOf(method))) {
+                fail("The adapter should have delegated the method '" + signatureOf(method) + "' to the wrapped instance, but did not.");
+            }
+        }
+    }
+
+    @Test
+    public void testServletContextRetrieval() throws Exception {
+        assertThat(this.testee.getServletContext()).isSameAs(this.servletContext);
+    }
+
+    private String signatureOf(Method m) {
+        return  m.getName() + "(" + join(m.getParameterTypes(), ", ") + ")";
+    }
+
+    private Object[] mockArgs(Method method) {
+        return stream(method.getParameterTypes()).map(type -> {
+                    if (!type.isPrimitive()) {
+                        return null;
+                    }
+                    if (type == boolean.class) {
+                        return false;
+                    }
+                    throw new AssertionError("Unable to mock type " + type + ".");
+                }).toArray();
+    }
+}


### PR DESCRIPTION
#144 

- Added script view resolution leveraging sling resource types
- Enabled WebApplicationContext support and thereby spring form taglib support in the process
- Enable ServletContextAware and ServletConfigAware in the process, thus improving compliance to standard WebApplicationContext setups