### PR TITLE
Mark dependency to tld-generator as optional.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -349,6 +349,7 @@
                 <artifactId>tld-generator</artifactId>
                 <version>1.1</version>
                 <scope>compile</scope>
+                <optional>true</optional>
                 <exclusions>
                     <exclusion>
                         <artifactId>javax.servlet-api</artifactId>


### PR DESCRIPTION
Prevents it being added as transitive dependency to clients.