### PR TITLE
Tld generator removed - dep update fixes

### DIFF
--- a/api-tld/pom.xml
+++ b/api-tld/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>io.neba.neba-api-tld</artifactId>
+    <packaging>jar</packaging>
+    <name>NEBA API TLD</name>
+
+    <description>
+        Annotations and annotation processor for generating JSP Tag Library Descriptors (TLD).
+    </description>
+
+    <parent>
+        <groupId>io.neba</groupId>
+        <artifactId>io.neba.neba-parent</artifactId>
+        <version>5.2.4-SNAPSHOT</version>
+    </parent>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- Only need javax.annotation.processing for AbstractProcessor -->
+    </dependencies>
+</project>

--- a/api-tld/src/main/java/io/neba/api/tags/Tag.java
+++ b/api-tld/src/main/java/io/neba/api/tags/Tag.java
@@ -14,17 +14,25 @@
   limitations under the License.
 */
 
-/**
- * Contains the NEBA tag libraries.
- * All tag libraries contained in this package are not extensible to prevent direct dependencies
- * of project-specific implementations to the NEBA core, i.e. to prevent
- * project code to inherit from these tag implementations.
- */
-@Deprecated
-@TagLibrary(
-        value = "http://neba.io/1.0",
-        descriptorFile = "neba.tld",
-        shortName = "neba",
-        description = "NEBA tag library"
-)
 package io.neba.api.tags;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a JSP tag. Used on {@link javax.servlet.jsp.tagext.TagSupport} subclasses
+ * to generate the tag metadata in the TLD.
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface Tag {
+
+    /**
+     * Description of the tag.
+     */
+    String description();
+}

--- a/api-tld/src/main/java/io/neba/api/tags/TagAttribute.java
+++ b/api-tld/src/main/java/io/neba/api/tags/TagAttribute.java
@@ -1,0 +1,43 @@
+/*
+  Copyright 2013 the original author or authors.
+
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package io.neba.api.tags;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a JSP tag attribute. Used on setter methods of tag classes
+ * to generate the attribute metadata in the TLD.
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.METHOD)
+public @interface TagAttribute {
+
+    /**
+     * Description of the attribute.
+     */
+    String description();
+
+    /**
+     * Whether the attribute supports runtime expressions (rtexprvalue).
+     */
+    boolean runtimeValueAllowed() default false;
+}

--- a/api-tld/src/main/java/io/neba/api/tags/TagLibrary.java
+++ b/api-tld/src/main/java/io/neba/api/tags/TagLibrary.java
@@ -1,0 +1,52 @@
+/*
+  Copyright 2013 the original author or authors.
+
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package io.neba.api.tags;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a JSP tag library. Used on package-info.java to generate the TLD descriptor.
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.PACKAGE)
+public @interface TagLibrary {
+
+    /**
+     * The tag library URI (e.g. {@code http://neba.io/1.0}).
+     */
+    String value();
+
+    /**
+     * The output TLD filename (e.g. {@code neba.tld}).
+     */
+    String descriptorFile();
+
+    /**
+     * Short name for the tag library (e.g. {@code neba}).
+     */
+    String shortName();
+
+    /**
+     * Description of the tag library.
+     */
+    String description();
+}

--- a/api-tld/src/main/java/io/neba/api/tags/processor/TldProcessor.java
+++ b/api-tld/src/main/java/io/neba/api/tags/processor/TldProcessor.java
@@ -1,0 +1,237 @@
+/*
+  Copyright 2013 the original author or authors.
+
+  Licensed under the Apache License, Version 2.0 the "License";
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package io.neba.api.tags.processor;
+
+import io.neba.api.tags.Tag;
+import io.neba.api.tags.TagAttribute;
+import io.neba.api.tags.TagLibrary;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Annotation processor that generates TLD (Tag Library Descriptor) files from
+ * {@link TagLibrary}, {@link Tag}, and {@link TagAttribute} annotations.
+ */
+@SupportedAnnotationTypes({
+    "io.neba.api.tags.TagLibrary",
+    "io.neba.api.tags.Tag",
+    "io.neba.api.tags.TagAttribute"
+})
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class TldProcessor extends AbstractProcessor {
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver()) {
+            return false;
+        }
+
+        TagLibraryInfo libraryInfo = null;
+        for (Element element : roundEnv.getElementsAnnotatedWith(TagLibrary.class)) {
+            if (element.getKind() == ElementKind.PACKAGE) {
+                PackageElement pkg = (PackageElement) element;
+                TagLibrary ann = pkg.getAnnotation(TagLibrary.class);
+                if (ann != null) {
+                    libraryInfo = new TagLibraryInfo(
+                            ann.value(),
+                            ann.descriptorFile(),
+                            ann.shortName(),
+                            ann.description()
+                    );
+                    break;
+                }
+            }
+        }
+
+        if (libraryInfo == null) {
+            return false;
+        }
+
+        List<TagInfo> tags = new ArrayList<>();
+        for (Element element : roundEnv.getElementsAnnotatedWith(Tag.class)) {
+            if (element.getKind() == ElementKind.CLASS) {
+                TypeElement type = (TypeElement) element;
+                Tag ann = type.getAnnotation(Tag.class);
+                if (ann != null) {
+                    String tagName = deriveTagName(type.getSimpleName().toString());
+                    List<AttributeInfo> attributes = new ArrayList<>();
+                    for (Element member : type.getEnclosedElements()) {
+                        if (member.getKind() == ElementKind.METHOD) {
+                            TagAttribute attrAnn = member.getAnnotation(TagAttribute.class);
+                            if (attrAnn != null) {
+                                String attrName = deriveAttributeName(((ExecutableElement) member).getSimpleName().toString());
+                                attributes.add(new AttributeInfo(attrName, attrAnn.description(), attrAnn.runtimeValueAllowed()));
+                            }
+                        }
+                    }
+                    tags.add(new TagInfo(
+                            tagName,
+                            type.getQualifiedName().toString(),
+                            ann.description(),
+                            attributes
+                    ));
+                }
+            }
+        }
+
+        try {
+            writeTld(libraryInfo, tags);
+        } catch (IOException e) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Failed to write TLD: " + e.getMessage());
+        }
+
+        return true;
+    }
+
+    private static String deriveTagName(String className) {
+        if (className.endsWith("Tag")) {
+            String base = className.substring(0, className.length() - 3);
+            return base.substring(0, 1).toLowerCase() + base.substring(1);
+        }
+        return className.substring(0, 1).toLowerCase() + className.substring(1);
+    }
+
+    private static String deriveAttributeName(String setterName) {
+        if (setterName.startsWith("set") && setterName.length() > 3) {
+            String base = setterName.substring(3);
+            return base.substring(0, 1).toLowerCase() + base.substring(1);
+        }
+        return setterName;
+    }
+
+    private void writeTld(TagLibraryInfo library, List<TagInfo> tags) throws IOException {
+        FileObject file = processingEnv.getFiler().createResource(
+                StandardLocation.CLASS_OUTPUT,
+                "",
+                "META-INF/" + library.descriptorFile
+        );
+
+        try (Writer writer = file.openWriter()) {
+            writer.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+            writer.write("<taglib xmlns=\"http://xmlns.jcp.org/xml/ns/javase\"\n");
+            writer.write("        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n");
+            writer.write("        xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/javase http://xmlns.jcp.org/xml/ns/javase/web-jsptaglibrary_2_1.xsd\"\n");
+            writer.write("        version=\"2.1\">\n");
+            writer.write("    <description>");
+            writer.write(escape(library.description));
+            writer.write("</description>\n");
+            writer.write("    <tlib-version>1.0</tlib-version>\n");
+            writer.write("    <short-name>");
+            writer.write(escape(library.shortName));
+            writer.write("</short-name>\n");
+            writer.write("    <uri>");
+            writer.write(escape(library.uri));
+            writer.write("</uri>\n");
+
+            for (TagInfo tag : tags) {
+                writer.write("    <tag>\n");
+                writer.write("        <name>");
+                writer.write(escape(tag.name));
+                writer.write("</name>\n");
+                writer.write("        <tag-class>");
+                writer.write(escape(tag.tagClass));
+                writer.write("</tag-class>\n");
+                writer.write("        <description>");
+                writer.write(escape(tag.description));
+                writer.write("</description>\n");
+                for (AttributeInfo attr : tag.attributes) {
+                    writer.write("        <attribute>\n");
+                    writer.write("            <name>");
+                    writer.write(escape(attr.name));
+                    writer.write("</name>\n");
+                    writer.write("            <required>false</required>\n");
+                    writer.write("            <rtexprvalue>");
+                    writer.write(attr.runtimeValueAllowed ? "true" : "false");
+                    writer.write("</rtexprvalue>\n");
+                    writer.write("            <description>");
+                    writer.write(escape(attr.description));
+                    writer.write("</description>\n");
+                    writer.write("        </attribute>\n");
+                }
+                writer.write("    </tag>\n");
+            }
+
+            writer.write("</taglib>\n");
+        }
+    }
+
+    private static String escape(String s) {
+        if (s == null) return "";
+        return s.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+
+    private static final class TagLibraryInfo {
+        final String uri;
+        final String descriptorFile;
+        final String shortName;
+        final String description;
+
+        TagLibraryInfo(String uri, String descriptorFile, String shortName, String description) {
+            this.uri = uri;
+            this.descriptorFile = descriptorFile;
+            this.shortName = shortName;
+            this.description = description;
+        }
+    }
+
+    private static final class TagInfo {
+        final String name;
+        final String tagClass;
+        final String description;
+        final List<AttributeInfo> attributes;
+
+        TagInfo(String name, String tagClass, String description, List<AttributeInfo> attributes) {
+            this.name = name;
+            this.tagClass = tagClass;
+            this.description = description;
+            this.attributes = attributes;
+        }
+    }
+
+    private static final class AttributeInfo {
+        final String name;
+        final String description;
+        final boolean runtimeValueAllowed;
+
+        AttributeInfo(String name, String description, boolean runtimeValueAllowed) {
+            this.name = name;
+            this.description = description;
+            this.runtimeValueAllowed = runtimeValueAllowed;
+        }
+    }
+}

--- a/api-tld/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/api-tld/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+io.neba.api.tags.processor.TldProcessor

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -50,6 +50,19 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.neba</groupId>
+                            <artifactId>io.neba.neba-api-tld</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
             <plugin>
@@ -60,6 +73,12 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>io.neba</groupId>
+            <artifactId>io.neba.neba-api-tld</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>javax.servlet.jsp</groupId>
             <artifactId>jsp-api</artifactId>
@@ -87,10 +106,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.tld-generator</groupId>
-            <artifactId>tld-generator</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/api/src/main/java/io/neba/api/tags/DefineObjectsTag.java
+++ b/api/src/main/java/io/neba/api/tags/DefineObjectsTag.java
@@ -21,10 +21,8 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.scripting.SlingScriptHelper;
-import tldgen.Tag;
-import tldgen.TagAttribute;
-
 import javax.annotation.CheckForNull;
+
 import javax.servlet.jsp.tagext.TagSupport;
 
 import static io.neba.api.Constants.MODEL;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/core/src/test/java/io/neba/core/resourcemodels/mapping/FieldValueMappingCallbackTest.java
+++ b/core/src/test/java/io/neba/core/resourcemodels/mapping/FieldValueMappingCallbackTest.java
@@ -1378,7 +1378,7 @@ public class FieldValueMappingCallbackTest {
     /**
      * A {@link AnnotatedFieldMapper} implementation must take
      * care to return an assignment-compatible value as a mapping result. However,
-     * there is no way to enforce this at compile time. This test verifies that a suitable exception
+     * there are no enforce this at compile time. This test verifies that a suitable exception
      * is thrown in case a field mapper returns an incompatible value at runtime.
      */
     @Test

--- a/core/src/test/java/io/neba/core/resourcemodels/metadata/ModelStatisticsConsolePluginTest.java
+++ b/core/src/test/java/io/neba/core/resourcemodels/metadata/ModelStatisticsConsolePluginTest.java
@@ -17,6 +17,7 @@
 package io.neba.core.resourcemodels.metadata;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.felix.webconsole.servlet.RequestVariableResolver;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -76,6 +77,11 @@ public class ModelStatisticsConsolePluginTest {
         doReturn(this.metadataList)
                 .when(this.registrar)
                 .get();
+
+        RequestVariableResolver variableResolver = new RequestVariableResolver();
+        variableResolver.put(RequestVariableResolver.KEY_APP_ROOT, "/system/console");
+        variableResolver.put(RequestVariableResolver.KEY_PLUGIN_ROOT, "/system/console/" + ModelStatisticsConsolePlugin.LABEL);
+        doReturn(variableResolver).when(this.request).getAttribute(RequestVariableResolver.REQUEST_ATTRIBUTE);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.2.1</version>
+				<version>3.18.0</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
@@ -196,7 +196,7 @@
 			<dependency>
 				<groupId>commons-fileupload</groupId>
 				<artifactId>commons-fileupload</artifactId>
-				<version>1.5</version>
+				<version>1.6.0</version>
 				<scope>provided</scope>
 			</dependency>
 
@@ -315,7 +315,7 @@
 			<dependency>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>org.apache.felix.webconsole</artifactId>
-				<version>4.2.2</version>
+				<version>4.9.10</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
@@ -389,7 +389,7 @@
 			<dependency>
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>
-				<version>3.14.0</version>
+				<version>3.27.7</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 	<url>https://neba.io</url>
 
 	<modules>
+		<module>api-tld</module>
 		<module>api</module>
 		<module>core</module>
 		<module>spring</module>
@@ -112,6 +113,12 @@
 				<groupId>javax.servlet</groupId>
 				<artifactId>javax.servlet-api</artifactId>
 				<version>4.0.0</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>javax.annotation</groupId>
+				<artifactId>javax.annotation-api</artifactId>
+				<version>1.3.2</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
@@ -335,23 +342,6 @@
 				<version>3.4.2</version>
 			</dependency>
 
-			<dependency>
-				<groupId>com.google.code.tld-generator</groupId>
-				<artifactId>tld-generator</artifactId>
-				<version>1.1</version>
-				<scope>provided</scope>
-				<optional>true</optional>
-				<exclusions>
-					<exclusion>
-						<artifactId>javax.servlet-api</artifactId>
-						<groupId>javax.servlet</groupId>
-					</exclusion>
-					<exclusion>
-						<artifactId>javax.servlet.jsp-api</artifactId>
-						<groupId>javax.servlet.jsp</groupId>
-					</exclusion>
-				</exclusions>
-			</dependency>
 			<dependency>
 				<groupId>com.google.code.findbugs</groupId>
 				<artifactId>jsr305</artifactId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -86,6 +86,10 @@
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.bgservlets</artifactId>
         </dependency>


### PR DESCRIPTION
Im going to attempt to get this to java21 for LTS.
to get here I'm dropping tld-generator as its dead weight, project is abandoned by google and will not get 21 support.

Fixes the haphazard dependabot updates that broke tests. 